### PR TITLE
Tweaks to Rust defn of kc_borrow_mut macro

### DIFF
--- a/sb_rs_port/src/krabcake.rs
+++ b/sb_rs_port/src/krabcake.rs
@@ -2,6 +2,7 @@ const fn vg_userreq_tool_base(a: u32, b: u32) -> u32 {
     ((a)&0xff) << 24 | ((b)&0xff) << 16
 }
 
+#[allow(dead_code)]
 #[repr(u32)]
 pub enum VgKrabcakeClientRequest {
     BorrowMut = vg_userreq_tool_base('K' as u32, 'C' as u32),

--- a/sb_rs_port/src/main.rs
+++ b/sb_rs_port/src/main.rs
@@ -1,5 +1,4 @@
 mod krabcake;
-use krabcake::VgKrabcakeClientRequest;
 
 #[repr(C)]
 struct Data<T> {

--- a/sb_rs_port/src/main.rs
+++ b/sb_rs_port/src/main.rs
@@ -59,25 +59,22 @@ macro_rules! kc_borrow_mut {
 }
 
 pub fn main() {
-    unsafe {
-        println!("Hello world!");
+    println!("Hello world!");
 
-        let mut val: u8 = 1;
-        let x = kc_borrow_mut!(val); // x = &mut val;
-        let y = kc_borrow_mut!(*x);
+    let mut val: u8 = 1;
+    let x = kc_borrow_mut!(val); // x = &mut val;
+    let y = kc_borrow_mut!(*x);
 
-        println!("before *y = 5, val: {}", val);
-        *y = 5;
-        println!("after *y = 5, val: {}", val);
+    println!("before *y = 5, val: {}", val);
+    *y = 5;
+    println!("after *y = 5, val: {}", val);
 
-        println!("before *x = 3, val: {}", val);
-        // Write through a pointer aliasing `y`
-        *x = 3;
-        println!("after *x = 3, val: {}", val);
+    println!("before *x = 3, val: {}", val);
+    // Write through a pointer aliasing `y`
+    *x = 3;
+    println!("after *x = 3, val: {}", val);
 
-        let end = *y;
+    let end = *y;
 
-        println!("Goodbye world, end: {}!", end);
-    }
+    println!("Goodbye world, end: {}!", end);
 }
-

--- a/sb_rs_port/src/main.rs
+++ b/sb_rs_port/src/main.rs
@@ -48,6 +48,11 @@ macro_rules! kc_borrow_mut {
         {
             let place = ::std::ptr::addr_of_mut!($data);
             let raw_ptr = valgrind_do_client_request_expr!(place, crate::krabcake::VgKrabcakeClientRequest::BorrowMut, place, 0x91, 0x92, 0x93, 0x94);
+            // When the necessary rustc machinery is all in place, all instances
+            // of `kc_borrow_mut!(PLACE)` will be replaced with `&mut PLACE`.
+            // Therefore, we go ahead and convert the `&raw` place above into an
+            // `&mut`, so that the appropriate type is inferred for the
+            // expression.
             unsafe { &mut *raw_ptr }
         }
     }

--- a/sb_rs_port/src/main.rs
+++ b/sb_rs_port/src/main.rs
@@ -1,5 +1,4 @@
 mod krabcake;
-use std::{arch::asm, ptr};
 use krabcake::VgKrabcakeClientRequest;
 
 #[repr(C)]
@@ -17,7 +16,7 @@ macro_rules! valgrind_do_client_request_expr {
     ( $zzq_default:expr, $request_code:expr,
       $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr ) => {
         {
-            let zzq_args = Data {
+            let zzq_args = crate::Data {
                 request_code: $request_code as u64,
                 arg1: $arg1,
                 arg2: $arg2,
@@ -28,7 +27,7 @@ macro_rules! valgrind_do_client_request_expr {
             let mut zzq_result = $zzq_default;
             #[allow(unused_unsafe)]
             unsafe {
-                asm!(
+                ::std::arch::asm!(
                     "rol rdi, 3",
                     "rol rdi, 13",
                     "rol rdi, 61",
@@ -47,8 +46,9 @@ macro_rules! valgrind_do_client_request_expr {
 macro_rules! kc_borrow_mut {
     ( $data:expr ) => {
         {
-            let place = ptr::addr_of_mut!($data);
-            valgrind_do_client_request_expr!(place, VgKrabcakeClientRequest::BorrowMut, place, 0x91, 0x92, 0x93, 0x94)
+            let place = ::std::ptr::addr_of_mut!($data);
+            let raw_ptr = valgrind_do_client_request_expr!(place, crate::krabcake::VgKrabcakeClientRequest::BorrowMut, place, 0x91, 0x92, 0x93, 0x94);
+            unsafe { &mut *raw_ptr }
         }
     }
 }


### PR DESCRIPTION
Tweak `kc_borrow_mut` macro so that it returns a `&mut _`.

Also, change the macros so that they use absolute paths, rather than rely on local imports of relevant modules (which complicates my attempts to use the macros in submodules of this crate).