### PR TITLE
added baseline.rs test that `make go` calls out to again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 sb_in_c
+baseline
 bin
 include
 lib

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ test: $(KC_BINS)
 # make that the case again, once we have the whole pipeline set up with
 # a patched rustc
 go: $(KC_BINS)
+	rustc -C opt-level=2 baseline.rs
+	./bin/valgrind -q --tool=krabcake ./baseline
 
 $(KC_BINS): $(INCLUDE_HDRS) $(wildcard $(KC_SRC)/*) $(KC_RS)
 	cd $(VG_SRC_ROOT) && $(MAKE) && $(MAKE) install

--- a/baseline.rs
+++ b/baseline.rs
@@ -1,0 +1,19 @@
+// This is a simple test file that side-steps the ui-test framework
+// and external crates, by importing submodule structure based on
+// knowledge of how the basictest is structured.
+//
+// This is probably an anti-pattern, but it was the easiest way for
+// pnkfelix to make my Makefile useful again for me.
+
+#[path = "kc/test_dependencies/src/lib.rs"]
+mod test_dependencies;
+
+#[path = "kc/tests/basictest.rs"]
+mod basictest;
+// re-import this here so that the macro inside basictest that assumes
+// it is crate root will still work.
+use basictest::Data;
+
+pub fn main() {
+    basictest::main();
+}

--- a/kc/tests/basictest.rs
+++ b/kc/tests/basictest.rs
@@ -1,7 +1,7 @@
 use test_dependencies::VgKrabcakeClientRequest;
 
 #[repr(C)]
-struct Data<T> {
+pub(crate) struct Data<T> {
     request_code: u64,
     arg1: *mut T,
     arg2: u64,


### PR DESCRIPTION
added baseline.rs test that `make go` calls out to again.

We avoid fragile code-duplication by introducing fragile coupling between this baseline and the interior of kc/tests; lol.