### PR TITLE
test demoing that C specifiers don't break things

### DIFF
--- a/kc/tests/print_stack_of_corner_cases.rs
+++ b/kc/tests/print_stack_of_corner_cases.rs
@@ -1,0 +1,8 @@
+use test_dependencies::{kc_borrow_mut, print_stack_of};
+
+fn main() {
+    let mut percent_s = 5;
+    let p = kc_borrow_mut!(percent_s);
+    let msg = b"C format sequences are %% %b %q %d %i %o %u %x %X %f %e %E %g %G %c %s\0";
+    print_stack_of(msg.as_ptr(), p);
+}

--- a/kc/tests/print_stack_of_corner_cases.stderr
+++ b/kc/tests/print_stack_of_corner_cases.stderr
@@ -1,0 +1,6 @@
+lib.rs: normalizing output...
+Hello world (from `rs_hello/src/lib.rs`)!
+kc_main.c: dispatching code 4b430000
+lib.rs: handle client request BORROW_MUT. borrowing_addr: 0x10000000
+kc_main.c: dispatching code 4b43000a
+print_stack_of `C format sequences are %% %b %q %d %i %o %u %x %X %f %e %E %g %G %c %s` (0x10000000): [Unique(1)]


### PR DESCRIPTION
Add test illustrating that the corner case of C format specifiers is handled.